### PR TITLE
ci: Add Play Store deployment workflow for AAB on main branch

### DIFF
--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -1,0 +1,69 @@
+name: Play Store Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Build & Deploy AAB to Play Store
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.7"
+          channel: stable
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool/
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Decode keystore
+        run: echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > android/app/bikebuddy.jks
+
+      - name: Create key.properties
+        run: |
+          echo "storePassword=${{ secrets.STORE_PASSWORD }}" > android/key.properties
+          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
+          echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
+          echo "storeFile=bikebuddy.jks" >> android/key.properties
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build AAB
+        run: |
+          flutter build appbundle --release \
+            --build-number=${{ github.run_number }} \
+            --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_URL }} \
+            --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+
+      - name: Deploy to Play Store internal track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          packageName: com.bikebuddy.mobile
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: internal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,5 +250,6 @@ ci: update flutter version in workflow
 | `docs:` | No | Documentation only |
 | `test:` | No | Adding or updating tests |
 | `ci:` | No | Workflow and pipeline changes |
+| `style:` | No | Formatting, whitespace, missing semicolons — no logic change |
 
 **Important:** `fix:` is for broken behaviour, not typos. A typo in a label is `chore:`, not `fix:`. Using `fix:` for trivial changes creates unnecessary patch releases.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "release-type": "dart",
   "packages": {
     ".": {
       "release-type": "dart",


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Play Store deployment, updates the documentation to include a new commit type, and makes a minor configuration change. The most significant change is the addition of an automated workflow to build and deploy the app to the Play Store internal track.

**CI/CD improvements:**
* Added a new workflow file `.github/workflows/play-store-deploy.yml` to automate building and deploying the Flutter app as an AAB to the Play Store internal track, including steps for dependency caching, keystore setup, versioning, and deployment.

**Documentation updates:**
* Added a new commit type `style:` to `CLAUDE.md` for formatting and non-functional code changes.

**Configuration changes:**
* Removed a redundant top-level `release-type` field from `release-please-config.json` to avoid duplication.## What does this PR do?

<!-- A clear one or two sentence summary of the change. -->

## Linked issue

Closes #14 

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Chore / config
- [ ] Docs
