### PR TITLE
ci: gate dev build and release-please on CI passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - dev
   pull_request:
     branches:
       - dev

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,7 +1,10 @@
 name: Dev Build
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - dev
 
@@ -12,10 +15,13 @@ jobs:
   build:
     name: Build & Pre-release APK
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -72,4 +78,4 @@ jobs:
 
             - Branch: `dev`
             - Build: `#${{ github.run_number }}`
-            - Commit: `${{ github.sha }}`
+            - Commit: `${{ github.event.workflow_run.head_sha }}`

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,10 @@
 name: Release Please
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - dev
 
@@ -12,6 +15,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## What does this PR do?

Gates the dev build (APK) and Release Please workflows behind CI — if flutter analyze or flutter test fails, neither runs.

## Linked issue

N/A

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Chore / config
- [ ] Docs

## Acceptance criteria

<!-- Copy the acceptance criteria from the linked issue and check them off. -->

- [x] Dev build does not run when CI fails
- [x] Release Please does not run when CI fails
- [x] Both still run automatically when CI passes

## Screenshots

<!-- Required for any UI change. Before and after if modifying existing UI. Delete this section if not applicable. -->

## Notes for reviewer

CI now also triggers on push to `dev` (in addition to pull requests) so that `workflow_run` has something to watch. Dev build checks out the exact commit SHA that passed CI via `github.event.workflow_run.head_sha`.