### PR TITLE
fix(ci): simplify release-please trigger to push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,7 @@
 name: Release Please
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
     branches:
       - main
 
@@ -15,8 +12,6 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && !startsWith(github.event.workflow_run.head_commit.message, 'chore(main): release') }}
-
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for release automation. The workflow is now triggered by pushes to the `main` branch instead of being triggered after the CI workflow completes. Additionally, a conditional check that prevented releases on certain commit messages has been removed.

**Workflow trigger changes:**

* Changed the trigger in `.github/workflows/release-please.yml` from running on successful completion of the `CI` workflow to running on every push to the `main` branch.

**Workflow condition simplification:**

* Removed the `if` condition that checked the CI workflow conclusion and commit message, simplifying when the release step runs.## What does this PR do?

