### PR TITLE
chore(ci): change play store deploy status to completed

### DIFF
--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -69,4 +69,4 @@ jobs:
           packageName: com.bikebuddy.mobile
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
-          status: draft
+          status: completed


### PR DESCRIPTION
This PR changes the deploy status to completed to fully publish releases to the internal track automatically without manual confirmation.